### PR TITLE
Remove absolute `twinotter` imports

### DIFF
--- a/twinotter/plots/basic_flight_track.py
+++ b/twinotter/plots/basic_flight_track.py
@@ -11,8 +11,8 @@ import matplotlib.patches as mpatches
 from pathlib import Path
 from datetime import datetime
 
-from twinotter import load_flight
-from twinotter.plots import plot_flight_path
+from .. import load_flight
+from . import plot_flight_path
 
 
 # HALO circle attributes

--- a/twinotter/plots/heights_and_legs.py
+++ b/twinotter/plots/heights_and_legs.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 import pandas as pd
 import xarray as xr
 
-import twinotter
+from .. import load_flight
 
 
 colors = {
@@ -27,7 +27,7 @@ def main():
 
 
 def generate(flight_data_path, legs_file):
-    ds = twinotter.load_flight(flight_data_path)
+    ds = load_flight(flight_data_path)
     df_legs = pd.read_csv(legs_file)
     ds_legs = xr.Dataset.from_dataframe(df_legs)
 
@@ -47,7 +47,7 @@ def generate(flight_data_path, legs_file):
         s_end = str(ds_leg.End.values)
         label = str(ds_leg.Label.values)
 
-        if not 'T' in s_start or not 'T' in s_end:
+        if 'T' not in s_start or 'T' not in s_end:
             date_start = ds.isel(Time=0).Time.dt.floor('D')
             date_end = ds.isel(Time=-1).Time.dt.floor('D')
 

--- a/twinotter/plots/interactive_flight_track.py
+++ b/twinotter/plots/interactive_flight_track.py
@@ -16,8 +16,8 @@ from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 import cartopy.crs as ccrs
 import pandas as pd
 
-from twinotter import load_flight
-from twinotter.plots import plot_flight_path
+from .. import load_flight
+from . import plot_flight_path
 
 
 def main():

--- a/twinotter/quicklook.py
+++ b/twinotter/quicklook.py
@@ -5,8 +5,8 @@ import pandas as pd
 import xarray as xr
 from tqdm import tqdm
 
-import twinotter
-from twinotter.plots import vertical_profile
+from . import load_flight
+from .plots import vertical_profile
 
 
 def main():
@@ -24,7 +24,7 @@ def main():
 
 
 def generate(flight_data_path, legs_file):
-    ds = twinotter.load_flight(flight_data_path)
+    ds = load_flight(flight_data_path)
     df_legs = pd.read_csv(legs_file)
     ds_legs = xr.Dataset.from_dataframe(df_legs)
 

--- a/twinotter/summary.py
+++ b/twinotter/summary.py
@@ -11,7 +11,7 @@ import parse
 import pandas as pd
 import xarray as xr
 
-import twinotter
+from . import generate_file_path, MASIN_CORE_FORMAT
 
 time_format = "{hours:02d}:{minutes:02d}:{seconds:02d} UTC"
 
@@ -34,7 +34,7 @@ def main():
 def generate(flight_data_path, flight_summary_path):
     # Get a list of netCDF files in the obs/ folder which match the expected
     # file pattern
-    fn_pattern = twinotter.MASIN_CORE_FORMAT.format(
+    fn_pattern = MASIN_CORE_FORMAT.format(
         date="*", revision="*", flight_num="*", freq="*"
     )
 
@@ -46,7 +46,7 @@ def generate(flight_data_path, flight_summary_path):
 
         for index, entry in flight_summary.iterrows():
             # Get the filename of existing entries in flight_information.csv
-            file_path = twinotter.generate_file_path(
+            file_path = generate_file_path(
                 flight_number=entry['Flight Number'],
                 date=entry['Date'],
                 frequency=entry['Frequency'],
@@ -73,7 +73,7 @@ def generate(flight_data_path, flight_summary_path):
     # Add these new files to the .csv
     for path in file_paths:
         # Get date, flight number, revision and frequency from the filename
-        flight_info = parse.parse(twinotter.MASIN_CORE_FORMAT, path.name)
+        flight_info = parse.parse(MASIN_CORE_FORMAT, path.name)
 
         # Format the date so it is more readable in the csv
         date = flight_info['date']


### PR DESCRIPTION
Should use relative imports inside package otherwise `twinotter` can't
be installed and used from command line.